### PR TITLE
Lighting changes in Arena Scene.

### DIFF
--- a/Source/Titanium/Titanium/Titanium/Arena/Tile.cs
+++ b/Source/Titanium/Titanium/Titanium/Arena/Tile.cs
@@ -31,6 +31,8 @@ namespace Titanium.Arena
         public static int TILE_WIDTH = 128;
         public static int TILE_HEIGHT = 128;
         public static float tileScale = 0.5f;
+        public static float UNDISCOVERED_AMBIENCE = 0.045f;
+        public static float DISCOVERED_AMBIENCE = 0.6f;
 
         private ArenaTiles tile;
         private Texture2D texture;
@@ -38,6 +40,8 @@ namespace Titanium.Arena
         //MovableModel
         public Matrix ModelMatrix;
         private Vector3 modelPosition;
+
+        public float TileAmbience;
 
 
         private Vector2 pos;
@@ -70,6 +74,30 @@ namespace Titanium.Arena
                         
             modelPosition = new Vector3(drawPos.X, -10, drawPos.Y);
 
+            //set tile ambience as arena ambience as default
+            TileAmbience = UNDISCOVERED_AMBIENCE;
+        }
+
+        /// <summary>
+        /// lights up the tile if it's been walked on
+        /// </summary>
+        public void setWalkedOnAmbience()
+        {
+            TileAmbience = DISCOVERED_AMBIENCE;
+        }
+
+        /// <summary>
+        /// returns true if the ambience is set
+        /// to discovered (a tile that was already walked on),
+        /// and false if it has not been discovered.
+        /// </summary>
+        /// <returns>true or flase depending on if the tile was discovered</returns>
+        public bool walkedOn()
+        {
+            if (TileAmbience != DISCOVERED_AMBIENCE)
+                return false;
+            else
+                return true;
         }
 
         /// <summary>
@@ -117,6 +145,7 @@ namespace Titanium.Arena
                         {
                             part.Effect = effect;
 
+                            effect.Parameters["AmbientIntensity"].SetValue(TileAmbience);
                             effect.Parameters["World"].SetValue(mesh.ParentBone.Transform * worldMatrix);
                             effect.Parameters["ModelTexture"].SetValue(texture);
 
@@ -126,6 +155,7 @@ namespace Titanium.Arena
                     // Draw the mesh, using the effects set above.
                     mesh.Draw();
                 }
+                effect.Parameters["AmbientIntensity"].SetValue(ArenaScene.ARENA_AMBIENCE);
             }
 
             foreach (Entity entity in entityList)

--- a/Source/Titanium/Titanium/Titanium/Camera.cs
+++ b/Source/Titanium/Titanium/Titanium/Camera.cs
@@ -44,6 +44,7 @@ namespace Titanium
         private float _clientW;//the client window's Width
         private float _clientH;//the client window's Height
         private float _aspectRatio;//aspectRatio
+        private Vector3 cameraPos;
 
         private BasicEffect _effect;//public; accessible for rendering purposes
 
@@ -67,6 +68,7 @@ namespace Titanium
             target = camTarget;//new Vector3();//looking at (0,0,0), the Origin/middle
 
             Vector3 camPos = position + camTarget;
+            cameraPos = camPos;
 
             View = Matrix.CreateLookAt(camTarget, target, Vector3.Up);
             Projection = Matrix.CreatePerspectiveFieldOfView(MathHelper.ToRadians(45f), _aspectRatio, 1f, 10000f);
@@ -97,6 +99,7 @@ namespace Titanium
         public void UpdateCamera(Vector3 CharacterPos)
         {
             Vector3 camPos = position + CharacterPos;
+            cameraPos = camPos;
             View = Matrix.CreateLookAt(camPos, CharacterPos, Vector3.Up);
             _effect.View = View;
         }
@@ -141,7 +144,7 @@ namespace Titanium
 
         public Vector3 getPosition()
         {
-            return position;
+            return cameraPos;
         }
 
         public Vector3 getLookAt()

--- a/Source/Titanium/Titanium/Titanium/Entities/ArenaEnemy.cs
+++ b/Source/Titanium/Titanium/Titanium/Entities/ArenaEnemy.cs
@@ -175,6 +175,7 @@ namespace Titanium.Entities
                         {
                             part.Effect = effect;
 
+                            effect.Parameters["AmbientIntensity"].SetValue(0.3f);
                             effect.Parameters["World"].SetValue(mesh.ParentBone.Transform * worldMatrix);
                             effect.Parameters["ModelTexture"].SetValue(texture);
 
@@ -184,6 +185,7 @@ namespace Titanium.Entities
                     // Draw the mesh, using the effects set above.
                     mesh.Draw();
                 }
+                effect.Parameters["AmbientIntensity"].SetValue(ArenaScene.ARENA_AMBIENCE);
             }
         }
 

--- a/Source/Titanium/Titanium/Titanium/Entities/Character.cs
+++ b/Source/Titanium/Titanium/Titanium/Entities/Character.cs
@@ -45,8 +45,10 @@ namespace Titanium.Entities
         private float rotAngle;
         private float scale;
 
+        private float SpotZoomAngle;
+
         // Possible player actions
-        static InputAction up, down, left, right;
+        static InputAction up, down, left, right, zoom;
 
         static Character()
         {
@@ -54,6 +56,7 @@ namespace Titanium.Entities
             down = InputAction.DOWN;
             left = InputAction.LEFT;
             right = InputAction.RIGHT;
+            zoom = InputAction.RCLICK;
         }
 
         /// <summary>
@@ -75,6 +78,7 @@ namespace Titanium.Entities
             myModel = null;
             stepsTaken = 0;
 
+            SpotZoomAngle = ArenaScene.instance.FlashLightAngle;
         }
 
         public void LoadModel(ContentManager cm, float aspectRatio)
@@ -216,7 +220,22 @@ namespace Titanium.Entities
         /// <param name="baseArena"></param>
         private void moveCharacter(InputState inputState)
         {
+            if(!_currentTile.walkedOn())
+                _currentTile.setWalkedOnAmbience();
+
+
             PlayerIndex player;
+            if(zoom.Evaluate(inputState,PlayerIndex.One, out player))
+            {
+                if (SpotZoomAngle == 10f)
+                    SpotZoomAngle = 35f;
+                else
+                    SpotZoomAngle = 10f;
+            }
+
+            ArenaScene.instance.FlashLightAngle += MathUtils.smoothChange(ArenaScene.instance.FlashLightAngle, SpotZoomAngle, 10);
+
+
             if (up.Evaluate(inputState, PlayerIndex.One, out player))
             {
                 if (_currentTile.getConnection(TileConnections.TOP) != null)

--- a/Source/Titanium/Titanium/Titanium/Entities/Items/Potion.cs
+++ b/Source/Titanium/Titanium/Titanium/Entities/Items/Potion.cs
@@ -16,7 +16,7 @@ namespace Titanium.Entities.Items
         //public Model myModel;
         private Vector3 Position;
         private Texture2D myTexture;
-        private float scale = 1f;
+        private float scale = 0.3f;
         private float modelOrientation = 0f;
         private float HealPercent;
         private Tile  PotionTile;

--- a/Source/Titanium/Titanium/Titanium/InputAction.cs
+++ b/Source/Titanium/Titanium/Titanium/InputAction.cs
@@ -133,7 +133,7 @@ namespace Titanium
             );
             RCLICK = new InputAction(
                 new Buttons[] { Buttons.RightStick },
-                new Keys[] { },
+                new Keys[] { Keys.NumPad0 },
                 true
             );
             LCLICK = new InputAction(

--- a/Source/Titanium/Titanium/Titanium/Scenes/ArenaScene.cs
+++ b/Source/Titanium/Titanium/Titanium/Scenes/ArenaScene.cs
@@ -45,6 +45,9 @@ namespace Titanium.Scenes
         private BasicEffect effect;
         public int potionsUsed;
 
+        public float FlashLightAngle;
+        public static float ARENA_AMBIENCE = 0.080f;
+
         public List<Entity> collidables;
 
         /**
@@ -85,6 +88,7 @@ namespace Titanium.Scenes
             if (effect == null)
                 effect = new BasicEffect(SceneManager.Game.GraphicsDevice);//null
 
+            FlashLightAngle = 10f;
             Hero = new Character();
             camera = new Camera(effect, SceneManager.Game.Window.ClientBounds.Width, SceneManager.Game.Window.ClientBounds.Height, SceneManager.GraphicsDevice.Viewport.AspectRatio, Hero.getPOSITION());
             //load model
@@ -95,6 +99,7 @@ namespace Titanium.Scenes
 
             potionsUsed = 0;
 
+            
             // Debug arena
             printDebugArena();
         }
@@ -109,6 +114,7 @@ namespace Titanium.Scenes
             //update Character
             Hero.Update(gameTime, inputState);
             camera.UpdateCamera(Hero.getPOSITION());
+
             
             // Update the tiles
             for (int i = 0; i < baseArena.GetLength(0); i++)
@@ -152,21 +158,21 @@ namespace Titanium.Scenes
             rs.CullMode = CullMode.None;
             SceneManager.GraphicsDevice.RasterizerState = rs;
             
-
+            Vector3 LightPos = new Vector3(Hero.getPOSITION().X, Hero.getPOSITION().Y + 400, Hero.getPOSITION().Z);//test light pos
             Vector3 position = camera.getPosition();
-            Vector3 LAt = camera.getLookAt() - position;
-
+            //Vector3 LAt = camera.getLookAt() - position;
+            Vector3 LAt = Hero.getPOSITION() - LightPos;
             HLSLeffect.CurrentTechnique = HLSLeffect.Techniques["ShaderTech"];
 
             HLSLeffect.Parameters["AmbientColor"].SetValue(Color.Gold.ToVector4());
-            HLSLeffect.Parameters["AmbientIntensity"].SetValue(0.9f);
+            HLSLeffect.Parameters["AmbientIntensity"].SetValue(ARENA_AMBIENCE);
             HLSLeffect.Parameters["fogColor"].SetValue(Color.Gray.ToVector4());
             HLSLeffect.Parameters["fogFar"].SetValue(1000.0f);
             HLSLeffect.Parameters["fogEnabled"].SetValue(true);
-            HLSLeffect.Parameters["FlashlightAngle"].SetValue(2.0f);
+            HLSLeffect.Parameters["FlashlightAngle"].SetValue(MathHelper.ToRadians(FlashLightAngle));
 
             HLSLeffect.Parameters["LightDirection"].SetValue(Vector3.Normalize(LAt));
-            HLSLeffect.Parameters["EyePosition"].SetValue(position);
+            HLSLeffect.Parameters["EyePosition"].SetValue(LightPos);//position
 
             HLSLeffect.Parameters["View"].SetValue(camera.getView());
             HLSLeffect.Parameters["Projection"].SetValue(camera.getProjection());

--- a/Source/Titanium/Titanium/TitaniumContent/Effects/Shader.fx
+++ b/Source/Titanium/Titanium/TitaniumContent/Effects/Shader.fx
@@ -23,8 +23,8 @@ bool fogEnabled;
 
 //Attenuation Variables
 float Kc = 1; //Constant Attenuation
-float Kl = 0.2; //Linear Attenuation
-float Kq = 0.1; //quadratic Attenuation
+float Kl = 0; //Linear Attenuation
+float Kq = 0; //quadratic Attenuation
 float FlashlightAngle;
 
 //Texture shading


### PR DESCRIPTION
enemies and tiles have their own ambient intensity.
Tiles light up as discovered.
RCLICK was assigned keys.numpad0
Spot light cone angle can be changed using numpad0 (keyboard) or RS (controller)
Potion model is smaller so I can see what I'm doing.
